### PR TITLE
tis: addressing potential int underflow

### DIFF
--- a/tis.c
+++ b/tis.c
@@ -168,6 +168,10 @@ size_t tis_recv(struct tpmbuff *buf)
 	hdr->size = be32_to_cpu(hdr->size);
 	hdr->code = be32_to_cpu(hdr->code);
 
+	/* protect against integer underflow */
+	if (hdr->size <= expected)
+		goto err;
+
 	/* hdr->size = header + data */
 	expected = hdr->size - expected;
 	buf_ptr = tpmb_put(buf, expected);


### PR DESCRIPTION
Under review it was determined that a malicious or erroneous TPM may
return a size equal to that of the header which will make it past
current guards but will result in an integer underflow. To address this
an additional guard is added after reading in the response header that
verifies the size field is larger than header before subtracting header
from the response size.

This addresses issue #1.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>