### PR TITLE
Remove release locality loop from tis_init()

### DIFF
--- a/tis.c
+++ b/tis.c
@@ -61,11 +61,6 @@ u8 tis_request_locality(u8 l)
 
 u8 tis_init(struct tpm *t)
 {
-        u8 i;
-
-        for (i=0; i <= TPM_MAX_LOCALITY; i++)
-                tpm_write8(ACCESS_RELINQUISH_LOCALITY, ACCESS(i));
-
         locality = TPM_NO_LOCALITY;
 
         if (tis_request_locality(0) != 0)


### PR DESCRIPTION
This loop was causing crashes on the Neon City platform and is not
needed in the end anyway.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>