### PR TITLE
tpm1: fix return value for extend

### DIFF
--- a/tpm1.h
+++ b/tpm1.h
@@ -107,6 +107,6 @@ struct tpm_extend_resp {
 };
 
 /* TPM Commands */
-u8 tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d);
+int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d);
 
 #endif


### PR DESCRIPTION
This commit corrects the return value from the PCR extend function to
match the TPM2 PCR extend return values.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>