### PR TITLE
Numerous fixes to make TPM1.2 extend work

### DIFF
--- a/crb.c
+++ b/crb.c
@@ -113,19 +113,19 @@ struct tpm_crb_intf_id_ext {
 /* TPM Duration A: 20ms */
 static void duration_a(void)
 {
-	tpm_udelay(20);
+	tpm_mdelay(20);
 }
 
 /* TPM Duration B: 750ms */
 static void duration_b(void)
 {
-	tpm_udelay(750);
+	tpm_mdelay(750);
 }
 
 /* TPM Duration C: 1000ms */
 static void duration_c(void)
 {
-	tpm_udelay(1000);
+	tpm_mdelay(1000);
 }
 
 static u8 is_idle(void)

--- a/tpm2_cmds.c
+++ b/tpm2_cmds.c
@@ -8,9 +8,10 @@
 
 #ifdef LINUX_KERNEL
 
-#include <asm/byteorder.h>
 #include <linux/types.h>
+#include <linux/string.h>
 #include <linux/errno.h>
+#include <asm/byteorder.h>
 
 #elif defined LINUX_USERSPACE
 
@@ -141,6 +142,7 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
+		ret = -ENOSYS;
 		break;
 	case TPM_TIS:
 		ret = tis_send(b);
@@ -150,6 +152,7 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
+		ret = -ENOSYS;
 		break;
 	}
 

--- a/tpm_common.h
+++ b/tpm_common.h
@@ -77,46 +77,46 @@ struct tpm_intf_capability {
 	};
 } __packed;
 
-void tpm_io_delay(void);
 void tpm_udelay(int loops);
+void tpm_mdelay(int ms);
 
 /* Timeouts defined in Table 16 from the TPM2 PTP and
      Table 15 from the PC Client TIS */
 /* TPM Timeout A: 750ms */
 static inline void timeout_a(void)
 {
-	tpm_udelay(750);
+	tpm_mdelay(750);
 }
 
 /* TPM Timeout B: 2000ms */
 static inline void timeout_b(void)
 {
-	tpm_udelay(2000);
+	tpm_mdelay(2000);
 }
 
 /* Timeouts C & D are different between 1.2 & 2.0 */
-/* TPM1.2 Timeout C: 200ms */
+/* TPM1.2 Timeout C: 750ms */
 static inline void tpm1_timeout_c(void)
 {
-	tpm_udelay(750);
+	tpm_mdelay(750);
 }
 
-/* TPM1.2 Timeout D: 30ms */
+/* TPM1.2 Timeout D: 750ms */
 static inline void tpm1_timeout_d(void)
 {
-	tpm_udelay(750);
+	tpm_mdelay(750);
 }
 
 /* TPM2 Timeout C: 200ms */
 static inline void tpm2_timeout_c(void)
 {
-	tpm_udelay(200);
+	tpm_mdelay(200);
 }
 
 /* TPM2 Timeout D: 30ms */
 static inline void tpm2_timeout_d(void)
 {
-	tpm_udelay(30);
+	tpm_mdelay(30);
 }
 
 u8 tpm_read8(u32 field);

--- a/tpmio.c
+++ b/tpmio.c
@@ -3,7 +3,6 @@
  *
  * Author(s):
  *      Daniel P. Smith <dpsmith@apertussolutions.com>
- *
  */
 
 #ifdef LINUX_KERNEL
@@ -16,7 +15,7 @@
 #include "tpm.h"
 #include "tpm_common.h"
 
-void tpm_io_delay(void)
+static noinline void tpm_io_delay(void)
 {
 	/* This is the default delay type in native_io_delay */
 	asm volatile ("outb %al, $0x80");
@@ -24,8 +23,16 @@ void tpm_io_delay(void)
 
 void tpm_udelay(int loops)
 {
-        while (loops--)
-                tpm_io_delay();     /* Approximately 1 us */
+	while (loops--)
+		tpm_io_delay();	/* Approximately 1 us */
+}
+
+void tpm_mdelay(int ms)
+{
+	int i;
+
+	for (i = 0; i < ms; i++)
+		tpm_udelay(1000);
 }
 
 u8 tpm_read8(u32 field)


### PR DESCRIPTION
 - Fix timeouts to be in ms rather than us.
 - Extend input data must be big endian.
 - Do not extend out buffer twice and fetch the size before
   calling tis_recv().
 - Add error codes for unsupported interface types.
 - Fix some includes and formatting.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>