### PR TITLE
Fixes from March 2020 checkpatch run

### DIFF
--- a/crb.c
+++ b/crb.c
@@ -34,7 +34,7 @@
 #define TPM_CRB_CTRL_RSP_ADDR	0x0068
 #define TPM_CRB_DATA_BUFFER	0x0080
 
-#define REGISTER(l,r)		(((l) << 12) | r)
+#define REGISTER(l, r)		(((l) << 12) | r)
 
 static u8 locality = TPM_NO_LOCALITY;
 
@@ -107,8 +107,10 @@ struct tpm_crb_intf_id_ext {
 	};
 } __packed;
 
-/* Durations derived from Table 15 of the PTP but is purely an artifact of this
- * implementation */
+/*
+ * Durations derived from Table 15 of the PTP but is purely an artifact of this
+ * implementation
+ */
 
 /* TPM Duration A: 20ms */
 static void duration_a(void)
@@ -132,10 +134,9 @@ static u8 is_idle(void)
 {
 	struct tpm_crb_ctrl_sts ctl_sts;
 
-	ctl_sts.val = tpm_read32(REGISTER(locality,TPM_CRB_CTRL_STS));
-	if (ctl_sts.tpm_idle == 1) {
+	ctl_sts.val = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_STS));
+	if (ctl_sts.tpm_idle == 1)
 		return 1;
-	}
 
 	return 0;
 }
@@ -144,7 +145,7 @@ static u8 is_ready(void)
 {
 	struct tpm_crb_ctrl_sts ctl_sts;
 
-	ctl_sts.val = tpm_read32(REGISTER(locality,TPM_CRB_CTRL_STS));
+	ctl_sts.val = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_STS));
 	return ctl_sts.val == 0;
 }
 
@@ -153,9 +154,8 @@ static u8 is_cmd_exec(void)
 	u32 ctrl_start;
 
 	ctrl_start = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_START));
-	if (ctrl_start == 1) {
+	if (ctrl_start == 1)
 		return 1;
-	}
 
 	return 0;
 }
@@ -166,7 +166,7 @@ static u8 cmd_ready(void)
 
 	if (is_idle()) {
 		ctl_req.cmd_ready = 1;
-		tpm_write32(ctl_req.val, REGISTER(locality,TPM_CRB_CTRL_REQ));
+		tpm_write32(ctl_req.val, REGISTER(locality, TPM_CRB_CTRL_REQ));
 		tpm2_timeout_c();
 
 		if (is_idle())
@@ -184,12 +184,10 @@ static void go_idle(void)
 		return;
 
 	ctl_req.go_idle = 1;
-	tpm_write32(ctl_req.val, REGISTER(locality,TPM_CRB_CTRL_REQ));
+	tpm_write32(ctl_req.val, REGISTER(locality, TPM_CRB_CTRL_REQ));
 
 	/* pause to give tpm time to complete the request */
 	tpm2_timeout_c();
-
-	return;
 }
 
 static void crb_relinquish_locality_internal(u16 l)
@@ -213,8 +211,8 @@ u8 crb_request_locality(u8 l)
 	if (loc_state.loc_assigned == 1) {
 		if (loc_state.active_locality == l) {
 			locality = l;
-                        return locality;
-                }
+			return locality;
+		}
 
 		crb_relinquish_locality_internal(loc_state.loc_assigned);
 	}
@@ -242,13 +240,13 @@ u8 crb_init(struct tpm *t)
 	u8 i;
 	struct tpm_crb_intf_id_ext id;
 
-	for (i=0; i<=TPM_MAX_LOCALITY; i++)
+	for (i = 0; i <= TPM_MAX_LOCALITY; i++)
 		crb_relinquish_locality_internal(i);
 
 	if (crb_request_locality(0) == TPM_NO_LOCALITY)
 		return 0;
 
-	id.val = tpm_read32(REGISTER(0,TPM_CRB_INTF_ID+4));
+	id.val = tpm_read32(REGISTER(0, TPM_CRB_INTF_ID + 4));
 	t->vendor = ((id.vid & 0x00FF) << 8) | ((id.vid & 0xFF00) >> 8);
 	if ((t->vendor & 0xFFFF) == 0xFFFF)
 		return 0;
@@ -282,9 +280,10 @@ size_t crb_send(struct tpmbuff *buf)
 
 	tpm_write32(ctrl_start, REGISTER(locality, TPM_CRB_CTRL_START));
 
-	/* most command sequences this code is interested with operates with
+	/*
+	 * Most command sequences this code is interested with operates with
 	 * 20/750 duration/timeout schedule
-	 * */
+	 */
 	duration_a();
 	ctrl_start = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_START));
 	if (ctrl_start != 0) {

--- a/tis.c
+++ b/tis.c
@@ -50,43 +50,43 @@ static u32 burst_wait(void)
 
 void tis_relinquish_locality(void)
 {
-        if (locality < TPM_MAX_LOCALITY)
+	if (locality < TPM_MAX_LOCALITY)
 		tpm_write8(ACCESS_RELINQUISH_LOCALITY, ACCESS(locality));
 
-        locality = TPM_NO_LOCALITY;
+	locality = TPM_NO_LOCALITY;
 }
 
 u8 tis_request_locality(u8 l)
 {
-        if (l > TPM_MAX_LOCALITY)
-                return TPM_NO_LOCALITY;
+	if (l > TPM_MAX_LOCALITY)
+		return TPM_NO_LOCALITY;
 
 	if (l == locality)
 		return locality;
 
 	tis_relinquish_locality();
 
-        tpm_write8(ACCESS_REQUEST_USE, ACCESS(l));
+	tpm_write8(ACCESS_REQUEST_USE, ACCESS(l));
 
-        /* wait for locality to be granted */
-        if (tpm_read8(ACCESS(l)) & ACCESS_ACTIVE_LOCALITY)
-                locality = l;
+	/* wait for locality to be granted */
+	if (tpm_read8(ACCESS(l)) & ACCESS_ACTIVE_LOCALITY)
+		locality = l;
 
-        return locality;
+	return locality;
 }
 
 u8 tis_init(struct tpm *t)
 {
-        locality = TPM_NO_LOCALITY;
+	locality = TPM_NO_LOCALITY;
 
-        if (tis_request_locality(0) != 0)
-                return 0;
+	if (tis_request_locality(0) != 0)
+		return 0;
 
-        t->vendor = tpm_read32(DID_VID(0));
-        if ((t->vendor & 0xFFFF) == 0xFFFF)
-                return 0;
+	t->vendor = tpm_read32(DID_VID(0));
+	if ((t->vendor & 0xFFFF) == 0xFFFF)
+		return 0;
 
-        return 1;
+	return 1;
 }
 
 size_t tis_send(struct tpmbuff *buf)
@@ -99,8 +99,8 @@ size_t tis_send(struct tpmbuff *buf)
 		return 0;
 
 	for (status = 0; (status & STS_COMMAND_READY) == 0; ) {
-	       tpm_write8(STS_COMMAND_READY, STS(locality));
-	       status = tpm_read8(STS(locality));
+		tpm_write8(STS_COMMAND_READY, STS(locality));
+		status = tpm_read8(STS(locality));
 	}
 
 	buf_ptr = buf->head;
@@ -196,7 +196,7 @@ size_t tis_recv(enum tpm_family f, struct tpmbuff *buf)
 	/* hdr->size = header + data */
 	expected = hdr->size - expected;
 	buf_ptr = tpmb_put(buf, expected);
-	if (! buf_ptr)
+	if (!buf_ptr)
 		goto err;
 
 	/* read all data, except last byte */

--- a/tis.h
+++ b/tis.h
@@ -39,10 +39,10 @@
 
 static inline bool tis_data_available(int locality)
 {
-        int status;
+	int status;
 
-        status = tpm_read8(STS(locality));
-        return ((status & (STS_DATA_AVAIL | STS_VALID)) ==
+	status = tpm_read8(STS(locality));
+	return ((status & (STS_DATA_AVAIL | STS_VALID)) ==
 		(STS_DATA_AVAIL | STS_VALID));
 }
 

--- a/tpm.c
+++ b/tpm.c
@@ -37,7 +37,7 @@ static void find_interface_and_family(struct tpm *t)
 
 	/* Sort out whether if it is 1.2 */
 	intf_cap.val = tpm_read32(TPM_INTF_CAPABILITY_0);
-	if ((intf_cap.interface_version == TPM12_TIS_INTF_12)||
+	if ((intf_cap.interface_version == TPM12_TIS_INTF_12) ||
 	    (intf_cap.interface_version == TPM12_TIS_INTF_13)) {
 		t->family = TPM12;
 		t->intf = TPM_TIS;
@@ -150,8 +150,8 @@ int tpm_extend_pcr(struct tpm *t, u32 pcr, u16 algo,
 		}
 
 		d.pcr = pcr;
-		memcpy((void*)d.digest.sha1.digest,
-                        digest, SHA1_DIGEST_SIZE);
+		memcpy((void *)d.digest.sha1.digest,
+			digest, SHA1_DIGEST_SIZE);
 
 		ret = tpm1_pcr_extend(t, &d);
 	} else if (t->family == TPM20) {

--- a/tpm1_cmds.c
+++ b/tpm1_cmds.c
@@ -23,7 +23,6 @@
 
 #endif
 
-
 #include "tpm.h"
 #include "tpmbuff.h"
 #include "tis.h"
@@ -64,7 +63,7 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
-		ret = -ENOSYS;
+		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
 		if (be32_to_cpu(hdr->size) != tis_send(b))
@@ -76,7 +75,7 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
-		ret = -ENOSYS;
+		ret = -EBADRQC;
 		break;
 	}
 
@@ -101,7 +100,7 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
-		ret = -ENOSYS;
+		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
 		/* tis_recv() will increase the buffer size */
@@ -115,7 +114,7 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
-		ret = -ENOSYS;
+		ret = -EBADRQC;
 		break;
 	}
 
@@ -130,7 +129,7 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 	 * ordinal field, the return size and values point to this being
 	 * incorrect.
 	 *
-	 * Also tis_recv() converts the header back to CPU endianess.
+	 * Also tis_recv() converts the header back to CPU endianness.
 	 */
 	if (hdr->code != TPM_SUCCESS)
 		ret = -EAGAIN;

--- a/tpm2.h
+++ b/tpm2.h
@@ -25,7 +25,7 @@ struct tpm2b {
 };
 
 // Table 32  Definition of TPMA_SESSION Bits <  IN/OUT>
-struct tpma_session{
+struct tpma_session {
 	u8 continue_session  : 1;
 	u8 audit_exclusive   : 1;
 	u8 audit_reset       : 1;

--- a/tpm2_cmds.c
+++ b/tpm2_cmds.c
@@ -51,8 +51,8 @@ static u16 convert_digest_list(struct tpml_digest_values *digests)
 	u16 size = sizeof(digests->count);
 	struct tpmt_ha *h = digests->digests;
 
-	for (i=0; i<digests->count; i++) {
-		switch(h->alg) {
+	for (i = 0; i < digests->count; i++) {
+		switch (h->alg) {
 		case TPM_ALG_SHA1:
 			h->alg = cpu_to_be16(h->alg);
 			h = (struct tpmt_ha *)((u8 *)h + SHA1_SIZE);
@@ -142,7 +142,7 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
-		ret = -ENOSYS;
+		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
 		ret = tis_send(b);
@@ -152,7 +152,7 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
-		ret = -ENOSYS;
+		ret = -EBADRQC;
 		break;
 	}
 

--- a/tpm_buff.c
+++ b/tpm_buff.c
@@ -92,7 +92,6 @@ struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf intf, u8 locality)
 	case TPM_DEVNODE:
 		/* TODO: need implementation */
 		goto err;
-		break;
 	case TPM_TIS:
 		if (b->head)
 			goto reset;
@@ -101,14 +100,13 @@ struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf intf, u8 locality)
 		b->truesize = STATIC_TIS_BUFFER_SIZE;
 		break;
 	case TPM_CRB:
-		b->head = (u8 *)(u64)(TPM_MMIO_BASE + (locality << 12) \
+		b->head = (u8 *)(u64)(TPM_MMIO_BASE + (locality << 12)
 			       + TPM_CRB_DATA_BUFFER_OFFSET);
 		b->truesize = TPM_CRB_DATA_BUFFER_SIZE;
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
 		goto err;
-		break;
 	default:
 		goto err;
 	}

--- a/tpm_common.h
+++ b/tpm_common.h
@@ -80,8 +80,11 @@ struct tpm_intf_capability {
 void tpm_udelay(int loops);
 void tpm_mdelay(int ms);
 
-/* Timeouts defined in Table 16 from the TPM2 PTP and
-     Table 15 from the PC Client TIS */
+/*
+ * Timeouts defined in Table 16 from the TPM2 PTP and
+ * Table 15 from the PC Client TIS
+ */
+
 /* TPM Timeout A: 750ms */
 static inline void timeout_a(void)
 {

--- a/tpmbuff.h
+++ b/tpmbuff.h
@@ -27,7 +27,7 @@ void tpmb_free(struct tpmbuff *b);
 u8 *tpmb_put(struct tpmbuff *b, size_t size);
 size_t tpmb_trim(struct tpmbuff *b, size_t size);
 size_t tpmb_size(struct tpmbuff *b);
-struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf i, u8 locality);;
+struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf i, u8 locality);
 void free_tpmbuff(struct tpmbuff *b, enum tpm_hw_intf i);
 
 #endif

--- a/tpmio.c
+++ b/tpmio.c
@@ -37,28 +37,28 @@ void tpm_mdelay(int ms)
 
 u8 tpm_read8(u32 field)
 {
-	void *mmio_addr = (void*)(u64)(TPM_MMIO_BASE | field);
+	void *mmio_addr = (void *)(u64)(TPM_MMIO_BASE | field);
 
 	return ioread8(mmio_addr);
 }
 
 void tpm_write8(unsigned char val, u32 field)
 {
-	void *mmio_addr = (void*)(u64)(TPM_MMIO_BASE | field);
+	void *mmio_addr = (void *)(u64)(TPM_MMIO_BASE | field);
 
 	iowrite8(val, mmio_addr);
 }
 
 u32 tpm_read32(u32 field)
 {
-	void *mmio_addr = (void*)(u64)(TPM_MMIO_BASE | field);
+	void *mmio_addr = (void *)(u64)(TPM_MMIO_BASE | field);
 
 	return ioread32(mmio_addr);
 }
 
 void tpm_write32(unsigned int val, u32 field)
 {
-	void *mmio_addr = (void*)(u64)(TPM_MMIO_BASE | field);
+	void *mmio_addr = (void *)(u64)(TPM_MMIO_BASE | field);
 
 	iowrite32(val, mmio_addr);
 }


### PR DESCRIPTION
Mostly formatting changes. The script complained about useing ENOSYS
so switch to using EBADRQC.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>