### PR TITLE
tpm cmds: adding check for emtpy buffer

### DIFF
--- a/tpm1_cmds.c
+++ b/tpm1_cmds.c
@@ -38,6 +38,11 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 	struct tpm_extend_resp *resp;
 	size_t bytes, size;
 
+	if (b == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	if (!tpmb_reserve(b)) {
 		ret = -ENOMEM;
 		goto out;

--- a/tpm2_cmds.c
+++ b/tpm2_cmds.c
@@ -97,6 +97,11 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 	u16 size;
 	int ret = 0;
 
+	if (b == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	ret = tpm2_alloc_cmd(b, &cmd, TPM_ST_SESSIONS, TPM_CC_PCR_EXTEND);
 	if (ret < 0)
 		goto out;

--- a/tpm_buff.c
+++ b/tpm_buff.c
@@ -9,6 +9,7 @@
 #ifdef LINUX_KERNEL
 
 #include <linux/types.h>
+#include <linux/string.h>
 
 #elif defined LINUX_USERSPACE
 


### PR DESCRIPTION
The commands tpm2_pcr_extend and tpm1_pcr_extend expects to be passed a tpm instance that has an allocated buffer. As such this adds a check to ensure this expectation is met.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>