### PR TITLE
tpm2 auth: refactor and correct null auth

### DIFF
--- a/tpm2.h
+++ b/tpm2.h
@@ -68,7 +68,7 @@ struct tpm2_cmd {
 	struct tpm_header *header;
 	u32 *handles;			/* TPM Handles array	*/
 	u32 *auth_size;			/* Size of Auth Area	*/
-	struct tpms_auth_cmd *auth;	/* Authorization Area	*/
+	u8 *auth;			/* Authorization Area	*/
 	u8 *params;			/* Parameters		*/
 	u8 *raw;			/* internal raw buffer	*/
 };

--- a/tpm2_auth.c
+++ b/tpm2_auth.c
@@ -24,21 +24,33 @@
 #endif
 
 #include "tpm.h"
+#include "tpmbuff.h"
 #include "tpm2.h"
 #include "tpm2_constants.h"
 
 #define NULL_AUTH_SIZE 9
 
-u16 tpm2_null_auth_size(void)
+u32 tpm2_null_auth_size(void)
 {
 	return NULL_AUTH_SIZE;
 }
 
-u16 tpm2_null_auth(struct tpms_auth_cmd *a)
+u8 *tpm2_null_auth(struct tpmbuff *b)
 {
-	memset(a, 0, NULL_AUTH_SIZE);
+	u32 *handle;
+	u8 *auth = (u8 *)tpmb_put(b, NULL_AUTH_SIZE);
+	if (auth == NULL)
+		goto out;
 
-	*a->handle = cpu_to_be32(TPM_RS_PW);
+	memset(auth, 0, NULL_AUTH_SIZE);
 
-	return NULL_AUTH_SIZE;
+	/*
+	 * The handle, the first element, is the
+	 * only non-zero value in a NULL auth
+	 */
+	handle = (u32 *)auth;
+	*handle = cpu_to_be32(TPM_RS_PW);
+
+out:
+	return auth;
 }

--- a/tpm2_auth.h
+++ b/tpm2_auth.h
@@ -14,7 +14,7 @@
 
 #include "tpm2.h"
 
-u16 tpm2_null_auth_size(void);
-u16 tpm2_null_auth(struct tpms_auth_cmd *a);
+u32 tpm2_null_auth_size(void);
+u8 *tpm2_null_auth(struct tpmbuff *b);
 
 #endif

--- a/tpm2_cmds.c
+++ b/tpm2_cmds.c
@@ -93,7 +93,6 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 {
 	struct tpmbuff *b = t->buff;
 	struct tpm2_cmd cmd;
-	u8 *ptr;
 	u16 size;
 	int ret = 0;
 
@@ -120,13 +119,13 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 		goto free;
 	}
 
-	cmd.auth = (struct tpms_auth_cmd *)tpmb_put(b, tpm2_null_auth_size());
+	cmd.auth = tpm2_null_auth(b);
 	if (cmd.auth == NULL) {
 		ret = -ENOMEM;
 		goto free;
 	}
 
-	*cmd.auth_size = cpu_to_be32(tpm2_null_auth(cmd.auth));
+	*cmd.auth_size = cpu_to_be32(tpm2_null_auth_size());
 
 	size = convert_digest_list(digests);
 	if (size == 0) {


### PR DESCRIPTION
The existing population of the null auth was just wrong. This rectifies
the population of the buffer and refactors how the calls are made to
make things a little simplier and straightforward.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>