### PR TITLE
tpm1: clean up of extend command

### DIFF
--- a/tpm1_cmds.c
+++ b/tpm1_cmds.c
@@ -35,8 +35,7 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 	struct tpmbuff *b = t->buff;
 	struct tpm_header *hdr;
 	struct tpm_extend_cmd *cmd;
-	struct tpm_extend_resp *resp;
-	size_t bytes, size;
+	size_t size;
 
 	if (b == NULL) {
 		ret = -EINVAL;


### PR DESCRIPTION
Removes unused variables.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>